### PR TITLE
Remove dockerfile and add dotnet jenkins worker label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
-
-RUN apt-get update -y && apt-get install -y make python awscli

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def slack = new Slack(steps, REPO_NAME)
 slack.success(this, ':pipeline: Pipeline started')
 
 pipeline {
-    agent { label "node-v8" }
+    agent { label "dotnet" }
     environment {
         DOTNET_CLI_HOME = "/tmp/DOTNET_CLI_HOME"
         ARTIFACTORY_USER = credentials('monetate-jenkins-artifactory-user')
@@ -25,11 +25,6 @@ pipeline {
         }
 
         stage('Run Tests') {
-        	agent {
-				dockerfile {
-					label 'docker'
-				}
-			}
             steps {
                 script {
 					sh 'make dotnet-test'
@@ -38,11 +33,6 @@ pipeline {
         }
 
         stage('Artifact: tag and publish') {
-        	agent {
-				dockerfile {
-					label 'docker'
-				}
-			}
             when {
                 branch 'release';
             }


### PR DESCRIPTION
# Why
Uses a specific Jenkins node to run the dotnet commands instead of installing a multitude of things through docker which are already installed on Jenkins. This speeds up the validation steps dramatically. QoL improvement.

# How
SRE added the .NET5.0 to a Jenkins worker with the label "dotnet". Use this new label and remove the dockerfile.

# Validation
Validated on intbox and Jenkins

1. Post a PR that has non breaking changes.
2. Observe the Jenkins worker has passed successfully. 
3. Can observe greenlit status at bottom of this PR

## Demo
### After
<img width="901" alt="Screen Shot 2022-05-09 at 10 10 12 AM" src="https://user-images.githubusercontent.com/71725556/167437781-9c7f1046-5c38-4e6a-85e2-0b2ad4fd2e05.png">
<img width="1414" alt="Screen Shot 2022-05-09 at 10 10 35 AM" src="https://user-images.githubusercontent.com/71725556/167437796-228f57df-5fdb-4e4e-a952-a06e583c8742.png">

